### PR TITLE
Check for Joi.binary

### DIFF
--- a/src/schemas/Certificates.ts
+++ b/src/schemas/Certificates.ts
@@ -8,11 +8,14 @@ export interface CertificatesSchema {
 	signerKeyPassphrase?: string;
 }
 
+// Joi.binary is not available in the browser
+const maybeBinaryOrString = Joi.binary ? [Joi.binary(), Joi.string()] : [Joi.string()];
+
 export const CertificatesSchema = Joi.object<CertificatesSchema>()
 	.keys({
-		wwdr: Joi.alternatives(Joi.binary(), Joi.string()).required(),
-		signerCert: Joi.alternatives(Joi.binary(), Joi.string()).required(),
-		signerKey: Joi.alternatives(Joi.binary(), Joi.string()).required(),
+		wwdr: Joi.alternatives(...maybeBinaryOrString).required(),
+		signerCert: Joi.alternatives(...maybeBinaryOrString).required(),
+		signerKey: Joi.alternatives(...maybeBinaryOrString).required(),
 		signerKeyPassphrase: Joi.string(),
 	})
 	.required();


### PR DESCRIPTION
Per this release https://github.com/sideway/joi/issues/2037#:~:text=The%20browser%20build%20does%20not%20include%20TLD%20email%20validation%2C%20Joi.binary()%2C%20the%20describe/build%20functionality%2C%20or%20debug/tracing. Joi.binary doesn't work in the browser and yield an error as follows:

![image](https://user-images.githubusercontent.com/6671020/151848480-9114d178-e3c5-45d1-95cc-785ed17e2e9e.png)
